### PR TITLE
Shader Support

### DIFF
--- a/src/main/java/com/nyfaria/nyfsquiver/item/QuiverItem.java
+++ b/src/main/java/com/nyfaria/nyfsquiver/item/QuiverItem.java
@@ -20,6 +20,7 @@ import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
@@ -124,7 +125,7 @@ public class QuiverItem extends TrinketItem implements TrinketRenderer {
             matrices.pushPose();
             TrinketRenderer.translateToChest(matrices, (PlayerModel<AbstractClientPlayer>) contextModel, (AbstractClientPlayer) entity);
             matrices.translate(0, .5, translate);
-            blip.renderStatic(entity, stack, ItemDisplayContext.HEAD, true, matrices, vertexConsumers, entity.level(), light, light, light);
+            blip.renderStatic(entity, stack, ItemDisplayContext.HEAD, true, matrices, vertexConsumers, entity.level(), light, OverlayTexture.NO_OVERLAY, 0);
             matrices.popPose();
         }
 /*        HumanoidModel<LivingEntity> model = this.getModel();


### PR DESCRIPTION
Applying the "light" variable to "combinedOverlay" & "seed" causes the model to render black on the player when using shaders.

The appropriate values should be "OverlayTexture.NO_OVERLAY" for "combinedOverlay" and "0" for "seed".

Tested using Sodium, Indium, Iris with the shader Complimentary Reimagined.

Some screenshots of the before and after.
![Before Change with Shaders](https://github.com/Nyfaria/NyfsQuiver-Fabric/assets/8047187/60b4b99d-6451-4ef1-86dd-fd063e6f4078)
![Before Change without Shaders](https://github.com/Nyfaria/NyfsQuiver-Fabric/assets/8047187/e8b96bb7-f84e-4893-8de1-16c2a4cf9919)
![After Change with Shaders](https://github.com/Nyfaria/NyfsQuiver-Fabric/assets/8047187/6011b0c7-2c83-4fc9-8a33-929b8bec5c24)
![After Change without Shaders](https://github.com/Nyfaria/NyfsQuiver-Fabric/assets/8047187/82e73051-3116-434f-ab98-87116b93171e)


Hope to see this implemented! :)